### PR TITLE
feat(frontend): configure docker buildpack in CI workflow #30

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -47,6 +47,9 @@ jobs:
     name: Build Web
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      packages: write
     
     steps:
       - uses: actions/checkout@v4
@@ -64,3 +67,23 @@ jobs:
       - name: Build Web
         working-directory: ./frontend
         run: flutter build web --release
+
+      - name: Setup pack CLI
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: buildpacks/github-actions/setup-pack@v5.7.0
+
+      - name: Login to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Publish Image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          pack build ghcr.io/${{ github.repository }}-frontend:latest \
+            --path ./frontend/build/web \
+            --builder paketobuildpacks/builder-jammy-base \
+            --publish


### PR DESCRIPTION
## Descrição
Esta PR implementa a configuração do **Cloud Native Buildpacks** para o frontend (Flutter Web).

## Mudanças
- Adicionada geração de imagem Docker via Buildpack no workflow de CI.
- Configurada publicação automática para o GitHub Container Registry (GHCR) em pushes na branch `main`.
- Adicionadas permissões necessárias para escrita de pacotes no GitHub Actions.

## Como Testar
- O workflow será disparado automaticamente após o merge para a `main`.
- A imagem poderá ser encontrada em `ghcr.io/alexandrofs/graham-select-frontend:latest`.

Resolves #30