### PR TITLE
Feat: Implementação da Tela de Ranking e Correções no Kafka

### DIFF
--- a/backend/api/src/main/java/afsdigital/grahamselect/api/valuation/infrastructure/persistence/jpa/repository/RankingJpaRepository.java
+++ b/backend/api/src/main/java/afsdigital/grahamselect/api/valuation/infrastructure/persistence/jpa/repository/RankingJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Repository
 public interface RankingJpaRepository extends JpaRepository<RankedCompanyEntity, String> {
 
-    @Query(value = "SELECT c.id as symbol, c.name, iv.intrinsic_value as intrinsic_value, sp.price as current_price, (iv.intrinsic_value / sp.price) - 1 as margin_of_safety "
+    @Query(value = "SELECT c.ticker as symbol, c.name, iv.intrinsic_value as intrinsic_value, sp.price as current_price, (iv.intrinsic_value / sp.price) - 1 as margin_of_safety "
             +
             "FROM company_intrinsic_value iv " +
             "JOIN (SELECT company_id, MAX(calculation_date) as latest_date FROM company_intrinsic_value GROUP BY company_id) latest_iv "

--- a/backend/common/src/main/java/afsdigital/grahamselect/common/domain/entities/FinancialDataEvent.java
+++ b/backend/common/src/main/java/afsdigital/grahamselect/common/domain/entities/FinancialDataEvent.java
@@ -1,13 +1,17 @@
 package afsdigital.grahamselect.common.domain.entities;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Builder
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class FinancialDataEvent {
 
     private LocalDate resultDate; //Data do resultado financeiro

--- a/backend/valuation-service/src/main/resources/application.yml
+++ b/backend/valuation-service/src/main/resources/application.yml
@@ -20,9 +20,11 @@ spring:
     consumer:
       group-id: valuation-consumer-group
       auto-offset-reset: earliest
-      key-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
       properties:
+        spring.deserializer.key.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
         spring.json.trusted.packages: "afsdigital.grahamselect.*"
         spring.json.key.default.type: "afsdigital.grahamselect.common.domain.entities.FinancialDataKey"
         spring.json.value.default.type: "afsdigital.grahamselect.common.domain.entities.FinancialDataEvent"

--- a/frontend/devtools_options.yaml
+++ b/frontend/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -10,6 +10,13 @@ import 'src/features/upload/domain/usecases/upload_file_usecase.dart';
 import 'src/features/upload/data/repositories/upload_repository_impl.dart';
 import 'src/features/upload/data/datasources/upload_remote_data_source.dart';
 
+// Ranking Feature Imports
+import 'src/features/ranking/data/datasources/ranking_remote_data_source.dart';
+import 'src/features/ranking/data/repositories/ranking_repository_impl.dart';
+import 'src/features/ranking/domain/usecases/get_ranking_usecase.dart';
+import 'src/features/ranking/presentation/providers/ranking_provider.dart';
+import 'src/features/ranking/presentation/pages/ranking_page.dart';
+
 void main() {
   runApp(const GrahamSelectApp());
 }
@@ -21,8 +28,7 @@ final _router = GoRouter(
     GoRoute(path: '/upload', builder: (context, state) => const UploadPage()),
     GoRoute(
       path: '/ranking',
-      builder: (context, state) =>
-          const Scaffold(body: Center(child: Text('Ranking Page - Em breve'))),
+      builder: (context, state) => const RankingPage(),
     ),
   ],
 );
@@ -32,15 +38,23 @@ class GrahamSelectApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Dependency injection
+    // Shared dependencies
     final httpClient = http.Client();
-    final remoteDataSource = UploadRemoteDataSource(client: httpClient);
-    final repository = UploadRepositoryImpl(remoteDataSource);
-    final uploadUseCase = UploadFileUseCase(repository);
+
+    // Upload Feature DI
+    final uploadRemoteDataSource = UploadRemoteDataSource(client: httpClient);
+    final uploadRepository = UploadRepositoryImpl(uploadRemoteDataSource);
+    final uploadUseCase = UploadFileUseCase(uploadRepository);
+
+    // Ranking Feature DI
+    final rankingRemoteDataSource = RankingRemoteDataSource(client: httpClient);
+    final rankingRepository = RankingRepositoryImpl(rankingRemoteDataSource);
+    final getRankingUseCase = GetRankingUseCase(rankingRepository);
 
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => UploadProvider(uploadUseCase)),
+        ChangeNotifierProvider(create: (_) => RankingProvider(getRankingUseCase)),
       ],
       child: MaterialApp.router(
         title: 'Graham Select',

--- a/frontend/lib/src/features/ranking/data/datasources/ranking_remote_data_source.dart
+++ b/frontend/lib/src/features/ranking/data/datasources/ranking_remote_data_source.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/ranked_company_model.dart';
+
+class RankingRemoteDataSource {
+  final http.Client client;
+  final String baseUrl;
+
+  const RankingRemoteDataSource({
+    required this.client,
+    this.baseUrl = 'http://localhost:8080/api/v1',
+  });
+
+  Future<List<RankedCompanyModel>> getRankedCompanies() async {
+    try {
+      final response = await client.get(
+        Uri.parse('$baseUrl/ranked-companies'),
+        headers: {'Content-Type': 'application/json'},
+      );
+
+      if (response.statusCode == 200) {
+        final List<dynamic> jsonList = jsonDecode(response.body);
+        return jsonList.map((json) => RankedCompanyModel.fromJson(json)).toList();
+      } else {
+        throw Exception('Falha ao carregar ranking. Status: ${response.statusCode}');
+      }
+    } catch (e) {
+       throw Exception('Erro de conexão ou ao processar dados: $e');
+    }
+  }
+}

--- a/frontend/lib/src/features/ranking/data/models/ranked_company_model.dart
+++ b/frontend/lib/src/features/ranking/data/models/ranked_company_model.dart
@@ -1,0 +1,21 @@
+import '../../domain/entities/ranked_company.dart';
+
+class RankedCompanyModel extends RankedCompany {
+  const RankedCompanyModel({
+    required super.symbol,
+    required super.name,
+    required super.intrinsicValue,
+    required super.currentPrice,
+    required super.marginOfSafety,
+  });
+
+  factory RankedCompanyModel.fromJson(Map<String, dynamic> json) {
+    return RankedCompanyModel(
+      symbol: json['symbol'] ?? '',
+      name: json['name'] ?? '',
+      intrinsicValue: (json['intrinsicValue'] as num?)?.toDouble() ?? 0.0,
+      currentPrice: (json['currentPrice'] as num?)?.toDouble() ?? 0.0,
+      marginOfSafety: (json['marginOfSafety'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}

--- a/frontend/lib/src/features/ranking/data/repositories/ranking_repository_impl.dart
+++ b/frontend/lib/src/features/ranking/data/repositories/ranking_repository_impl.dart
@@ -1,0 +1,14 @@
+import '../../domain/entities/ranked_company.dart';
+import '../../domain/repositories/ranking_repository.dart';
+import '../datasources/ranking_remote_data_source.dart';
+
+class RankingRepositoryImpl implements RankingRepository {
+  final RankingRemoteDataSource remoteDataSource;
+
+  RankingRepositoryImpl(this.remoteDataSource);
+
+  @override
+  Future<List<RankedCompany>> getRankedCompanies() async {
+    return await remoteDataSource.getRankedCompanies();
+  }
+}

--- a/frontend/lib/src/features/ranking/domain/entities/ranked_company.dart
+++ b/frontend/lib/src/features/ranking/domain/entities/ranked_company.dart
@@ -1,0 +1,15 @@
+class RankedCompany {
+  final String symbol;
+  final String name;
+  final double intrinsicValue;
+  final double currentPrice;
+  final double marginOfSafety;
+
+  const RankedCompany({
+    required this.symbol,
+    required this.name,
+    required this.intrinsicValue,
+    required this.currentPrice,
+    required this.marginOfSafety,
+  });
+}

--- a/frontend/lib/src/features/ranking/domain/repositories/ranking_repository.dart
+++ b/frontend/lib/src/features/ranking/domain/repositories/ranking_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/ranked_company.dart';
+
+abstract class RankingRepository {
+  Future<List<RankedCompany>> getRankedCompanies();
+}

--- a/frontend/lib/src/features/ranking/domain/usecases/get_ranking_usecase.dart
+++ b/frontend/lib/src/features/ranking/domain/usecases/get_ranking_usecase.dart
@@ -1,0 +1,12 @@
+import '../entities/ranked_company.dart';
+import '../repositories/ranking_repository.dart';
+
+class GetRankingUseCase {
+  final RankingRepository repository;
+
+  GetRankingUseCase(this.repository);
+
+  Future<List<RankedCompany>> call() {
+    return repository.getRankedCompanies();
+  }
+}

--- a/frontend/lib/src/features/ranking/presentation/pages/ranking_page.dart
+++ b/frontend/lib/src/features/ranking/presentation/pages/ranking_page.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/ranking_provider.dart';
+import '../../domain/entities/ranked_company.dart';
+
+class RankingPage extends StatefulWidget {
+  const RankingPage({super.key});
+
+  @override
+  State<RankingPage> createState() => _RankingPageState();
+}
+
+class _RankingPageState extends State<RankingPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<RankingProvider>().fetchRanking();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Top 20 Graham'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => context.read<RankingProvider>().fetchRanking(),
+          ),
+        ],
+      ),
+      body: Consumer<RankingProvider>(
+        builder: (context, provider, child) {
+          switch (provider.state) {
+            case RankingState.loading:
+              return const Center(child: CircularProgressIndicator());
+            case RankingState.error:
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Icons.error_outline, size: 60, color: Colors.red),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Erro ao carregar ranking:',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        provider.errorMessage ?? 'Erro desconhecido',
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 24),
+                      ElevatedButton.icon(
+                        onPressed: () => provider.fetchRanking(),
+                        icon: const Icon(Icons.refresh),
+                        label: const Text('Tentar Novamente'),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            case RankingState.success:
+              if (provider.companies.isEmpty) {
+                 return const Center(child: Text('Nenhuma empresa encontrada com os critérios.'));
+              }
+              return _buildRankingTable(context, provider.companies);
+            case RankingState.idle:
+              return const SizedBox.shrink();
+          }
+        },
+      ),
+    );
+  }
+
+  Widget _buildRankingTable(BuildContext context, List<RankedCompany> companies) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.vertical,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: DataTable(
+          columns: const [
+            DataColumn(label: Text('Ticker', style: TextStyle(fontWeight: FontWeight.bold))),
+            DataColumn(label: Text('Nome', style: TextStyle(fontWeight: FontWeight.bold))),
+            DataColumn(label: Text('Preço Atual', style: TextStyle(fontWeight: FontWeight.bold)), numeric: true),
+            DataColumn(label: Text('Valor Intrínseco', style: TextStyle(fontWeight: FontWeight.bold)), numeric: true),
+            DataColumn(label: Text('Margem Seg.', style: TextStyle(fontWeight: FontWeight.bold)), numeric: true),
+          ],
+          rows: companies.map((company) {
+            return DataRow(cells: [
+              DataCell(Text(company.symbol, style: const TextStyle(fontWeight: FontWeight.bold))),
+              DataCell(Text(company.name)),
+              DataCell(Text('R\$ ${company.currentPrice.toStringAsFixed(2)}')),
+              DataCell(Text('R\$ ${company.intrinsicValue.toStringAsFixed(2)}')),
+              DataCell(Text('${(company.marginOfSafety * 100).toStringAsFixed(1)}%')),
+            ]);
+          }).toList(),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/src/features/ranking/presentation/providers/ranking_provider.dart
+++ b/frontend/lib/src/features/ranking/presentation/providers/ranking_provider.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+import '../../domain/entities/ranked_company.dart';
+import '../../domain/usecases/get_ranking_usecase.dart';
+
+enum RankingState { idle, loading, success, error }
+
+class RankingProvider extends ChangeNotifier {
+  final GetRankingUseCase getRankingUseCase;
+
+  RankingState _state = RankingState.idle;
+  List<RankedCompany> _companies = [];
+  String? _errorMessage;
+
+  RankingProvider(this.getRankingUseCase);
+
+  RankingState get state => _state;
+  List<RankedCompany> get companies => _companies;
+  String? get errorMessage => _errorMessage;
+
+  Future<void> fetchRanking() async {
+    _setState(RankingState.loading);
+    _errorMessage = null;
+
+    try {
+      _companies = await getRankingUseCase();
+      _setState(RankingState.success);
+    } catch (e) {
+      _errorMessage = e.toString();
+      _setState(RankingState.error);
+    }
+  }
+
+  void _setState(RankingState newState) {
+    _state = newState;
+    notifyListeners();
+  }
+}

--- a/frontend/test/home_page_test.dart
+++ b/frontend/test/home_page_test.dart
@@ -36,6 +36,6 @@ void main() {
     await tester.pumpAndSettle();
 
     // Verify navigation occurred (placeholder page should be visible)
-    expect(find.text('Ranking Page - Em breve'), findsOneWidget);
+    expect(find.text('Top 20 Graham'), findsOneWidget);
   });
 }

--- a/frontend/test/src/features/ranking/presentation/providers/ranking_provider_test.dart
+++ b/frontend/test/src/features/ranking/presentation/providers/ranking_provider_test.dart
@@ -1,0 +1,100 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frontend/src/features/ranking/presentation/providers/ranking_provider.dart';
+import 'package:frontend/src/features/ranking/domain/usecases/get_ranking_usecase.dart';
+import 'package:frontend/src/features/ranking/domain/entities/ranked_company.dart';
+import 'package:frontend/src/features/ranking/domain/repositories/ranking_repository.dart';
+
+// Manual Mock
+class ManualMockGetRankingUseCase implements GetRankingUseCase {
+  List<RankedCompany>? _response;
+  Exception? _error;
+  int callCount = 0;
+
+  @override
+  RankingRepository get repository => throw UnimplementedError();
+
+  void mockSuccess(List<RankedCompany> companies) {
+    _response = companies;
+    _error = null;
+  }
+
+  void mockFailure(Exception error) {
+    _error = error;
+    _response = null;
+  }
+
+  @override
+  Future<List<RankedCompany>> call() async {
+    callCount++;
+    // Simulate network delay
+    await Future.delayed(Duration(milliseconds: 10));
+    if (_error != null) throw _error!;
+    return _response!;
+  }
+}
+
+void main() {
+  late RankingProvider provider;
+  late ManualMockGetRankingUseCase mockGetRankingUseCase;
+
+  setUp(() {
+    mockGetRankingUseCase = ManualMockGetRankingUseCase();
+    provider = RankingProvider(mockGetRankingUseCase);
+  });
+
+  group('RankingProvider', () {
+    test('initial state should be idle', () {
+      expect(provider.state, RankingState.idle);
+      expect(provider.companies, isEmpty);
+      expect(provider.errorMessage, isNull);
+    });
+
+    test('should change state to loading and then success when fetchRanking is successful', () async {
+      // Arrange
+      final tCompanies = [
+        RankedCompany(
+          symbol: 'AAPL',
+          name: 'Apple Inc.',
+          currentPrice: 150.0,
+          intrinsicValue: 200.0,
+          marginOfSafety: 0.25,
+        )
+      ];
+      mockGetRankingUseCase.mockSuccess(tCompanies);
+
+      // Act
+      final future = provider.fetchRanking();
+
+      // Assert loading state
+      expect(provider.state, RankingState.loading);
+      
+      await future;
+
+      // Assert success state
+      expect(provider.state, RankingState.success);
+      expect(provider.companies, tCompanies);
+      expect(provider.errorMessage, isNull);
+      expect(mockGetRankingUseCase.callCount, 1);
+    });
+
+    test('should change state to loading and then error when fetchRanking fails', () async {
+      // Arrange
+      final tError = Exception('Failed to fetch data');
+      mockGetRankingUseCase.mockFailure(tError);
+
+      // Act
+      final future = provider.fetchRanking();
+      
+      expect(provider.state, RankingState.loading);
+
+      await future;
+
+      // Assert error state
+      expect(provider.state, RankingState.error);
+      expect(provider.companies, isEmpty);
+      expect(provider.errorMessage, contains('Failed to fetch data'));
+      expect(mockGetRankingUseCase.callCount, 1);
+    });
+  });
+}

--- a/start-app.sh
+++ b/start-app.sh
@@ -29,6 +29,7 @@ echo -e "${GREEN}[3/4] Iniciando Serviços Backend e Frontend...${NC}"
 cleanup() {
     echo -e "\n${RED}Finalizando serviços...${NC}"
     kill $API_PID $VALUATION_PID $FRONT_PID
+    docker-compose down
     exit
 }
 


### PR DESCRIPTION
Resolves #13.

## Mudanças Realizadas

### Frontend
- Implementação da tela de **Ranking de Empresas** (`RankingPage`).
- Visualização dos dados em formato de tabela (DataTable).
- Integração com backend através do `RankingRemoteDataSource` e `RankingProvider`.
- Testes unitários para o Provider e testes de integração para a navegação.

### Backend
- Criação das entidades de domínio `RankedCompany`.
- Implementação do endpoint GET `/ranked-companies`.
- Correção de bug no `RankingJpaRepository` que retornava ID ao invés do Ticker.
- Ajuste na configuração do Kafka Consumer para usar `ErrorHandlingDeserializer`, evitando loops infinitos em caso de erro de desserialização.
- Adição de construtores padrão no `FinancialDataEvent` para permitir a desserialização correta pelo Jackson.

## Testes Realizados
- Testes unitários de backend e frontend passaram.
- Teste manual da tela de ranking com dados reais do Kafka.
- Verificação de logs do Kafka sem erros de "poison pill".
