### PR TITLE
fix: corrige duplicação no Top 20 Graham e bugs no modal de Nova Operação

### DIFF
--- a/backend/api/src/main/java/afsdigital/grahamselect/api/valuation/infrastructure/persistence/jpa/repository/RankingJpaRepository.java
+++ b/backend/api/src/main/java/afsdigital/grahamselect/api/valuation/infrastructure/persistence/jpa/repository/RankingJpaRepository.java
@@ -13,14 +13,15 @@ public interface RankingJpaRepository extends JpaRepository<RankedCompanyEntity,
     @Query(value = "SELECT c.ticker as symbol, c.name, iv.intrinsic_value as intrinsic_value, sp.price as current_price, (iv.intrinsic_value / sp.price) - 1 as margin_of_safety "
             +
             "FROM company_intrinsic_value iv " +
-            "JOIN (SELECT company_id, MAX(calculation_date) as latest_date FROM company_intrinsic_value GROUP BY company_id) latest_iv "
-            +
+            "JOIN (SELECT company_id, MAX(calculation_date) as latest_date FROM company_intrinsic_value GROUP BY company_id) latest_iv " +
             "ON iv.company_id = latest_iv.company_id AND iv.calculation_date = latest_iv.latest_date " +
             "JOIN company c ON c.id = iv.company_id " +
             "JOIN (SELECT company_id, MAX(price_date) as latest_price_date FROM stock_price GROUP BY company_id) lp " +
             "ON iv.company_id = lp.company_id " +
-            "JOIN stock_price sp ON sp.company_id = lp.company_id AND sp.price_date = lp.latest_price_date " +
+            "JOIN (SELECT company_id, price_date, MAX(price) as price FROM stock_price GROUP BY company_id, price_date) sp " +
+            "ON sp.company_id = lp.company_id AND sp.price_date = lp.latest_price_date " +
             "ORDER BY margin_of_safety DESC " +
             "LIMIT 20", nativeQuery = true)
     List<RankedCompanyEntity> findTop20BestRanked();
 }
+

--- a/backend/valuation-service/src/main/java/afsdigital/grahamselect/valuation/infrastructure/persistence/ValuationRepositoryImpl.java
+++ b/backend/valuation-service/src/main/java/afsdigital/grahamselect/valuation/infrastructure/persistence/ValuationRepositoryImpl.java
@@ -52,12 +52,15 @@ public class ValuationRepositoryImpl implements ValuationRepository {
                      stockPrice.getCompanyId(), stockPrice.getDate());
         }
 
-        StockPriceEntity stockPriceEntity = StockPriceEntity.builder()
-                .id(UUID.randomUUID().toString())
-                .companyId(stockPrice.getCompanyId())
-                .priceDate(stockPrice.getDate())
-                .price(stockPrice.getPrice())
-                .build();
+        StockPriceEntity stockPriceEntity = stockPriceJpaRepository
+                .findFirstByCompanyIdAndPriceDate(stockPrice.getCompanyId(), stockPrice.getDate())
+                .orElseGet(() -> StockPriceEntity.builder()
+                        .id(UUID.randomUUID().toString())
+                        .companyId(stockPrice.getCompanyId())
+                        .priceDate(stockPrice.getDate())
+                        .build());
+        stockPriceEntity.setPrice(stockPrice.getPrice());
         stockPriceJpaRepository.save(stockPriceEntity);
+
     }
 }

--- a/backend/valuation-service/src/main/java/afsdigital/grahamselect/valuation/infrastructure/persistence/jpa/repository/StockPriceJpaRepository.java
+++ b/backend/valuation-service/src/main/java/afsdigital/grahamselect/valuation/infrastructure/persistence/jpa/repository/StockPriceJpaRepository.java
@@ -4,6 +4,11 @@ import afsdigital.grahamselect.valuation.infrastructure.persistence.jpa.entities
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 @Repository
 public interface StockPriceJpaRepository extends JpaRepository<StockPriceEntity, String> {
+    Optional<StockPriceEntity> findFirstByCompanyIdAndPriceDate(String companyId, LocalDate priceDate);
 }
+

--- a/docs/bmad/implementation-artifacts/spec-fix-top20-and-trade-modal-bugs.md
+++ b/docs/bmad/implementation-artifacts/spec-fix-top20-and-trade-modal-bugs.md
@@ -1,0 +1,84 @@
+---
+title: 'Correção de Bugs no Top 20 Graham e Modal de Nova Operação'
+type: 'bugfix'
+created: '2026-06-06T16:15:00-03:00'
+status: 'done'
+baseline_commit: '472e4ecb8e14407f7502cd0e4d2f373371445117'
+context:
+  - '{project-root}/docs/bmad/project-context.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** 
+1. Duplicação de registros de ativos no ranking "Top 20 Graham" devido a inserções de cotações redundantes na mesma data no banco e ausência de agrupamento/deduplicação na query nativa de ranking.
+2. Fechamento automático imediato com mensagem de sucesso ao abrir o modal "Nova Operação" pela primeira vez, devido ao compartilhamento de status de sucesso do dashboard.
+3. Impossibilidade de informar tickers customizados (não aceita o texto digitado se não for clicado no dropdown de sugestões do Autocomplete) e bloqueio da digitação de preços com centavos usando vírgula (separador decimal brasileiro).
+
+**Approach:** 
+1. Ajustar a query nativa do ranking para realizar o join sobre uma subquery agrupada de cotações, e alterar o serviço de valuation para buscar cotações existentes da mesma empresa no mesmo dia, atualizando o valor (garantindo que fique com o preço mais atualizado recebido) em vez de inserir novas linhas.
+2. Criar estados e tratamentos de status específicos para trade manual no `PortfolioProvider` (`tradeStatus`), isolando-o dos estados gerais do dashboard.
+3. Integrar o `_tickerController` no `Autocomplete` e atualizar a regex de formatação de preço do TextFormField para permitir vírgula, efetuando a normalização antes do parsing de double.
+
+## Boundaries & Constraints
+
+**Always:** 
+- Seguir as regras de datas UTC de forma consistente (usando `ZoneOffset.UTC`).
+- Manter todos os testes unitários e de integração existentes passando.
+- Usar logs apropriados (INFO nas entradas de API e ERROR em exceções).
+- Manter o padrão de arquitetura multi-módulo no backend e Provider no frontend.
+
+**Ask First:** 
+- Nenhuma decisão que requeira aprovação prévia foi identificada.
+
+**Never:** 
+- Nunca realizar chamadas síncronas entre os módulos `api` e `valuation-service`.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Salvamento de cotação | Valuation com cotação existente na mesma data | Atualiza o registro existente de `stock_price` com o novo preço | Log de depuração ou aviso se necessário |
+| Abertura do modal | Dashboard carregado com sucesso (`status = success`) | Modal abre vazio, no estado `initial` para o trade | Sem SnackBar de sucesso |
+| Digitação manual de Ticker | Usuário digita "SANB11" e clica em salvar sem usar dropdown | Trade é enviado com ticker "SANB11" | Validação normal de ticker vazio |
+| Preço com vírgula | Usuário digita "40,89" | Parser converte para "40.89" e persiste no banco | Validação normal de número inválido |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `backend/api/src/main/java/afsdigital/grahamselect/api/valuation/infrastructure/persistence/jpa/repository/RankingJpaRepository.java` -- Interface contendo a query SQL nativa do ranking.
+- `backend/valuation-service/src/main/java/afsdigital/grahamselect/valuation/infrastructure/persistence/ValuationRepositoryImpl.java` -- Repositório onde as cotações de stock price são salvas na base.
+- `backend/valuation-service/src/main/java/afsdigital/grahamselect/valuation/infrastructure/persistence/jpa/repository/StockPriceJpaRepository.java` -- Repositório JPA de cotações do valuation service.
+- `frontend/lib/src/features/portfolio/presentation/providers/portfolio_provider.dart` -- Gerenciador de estado do portfólio.
+- `frontend/lib/src/features/portfolio/presentation/widgets/manual_operation_entry.dart` -- Widget do modal de nova operação.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `backend/valuation-service/src/main/java/afsdigital/grahamselect/valuation/infrastructure/persistence/jpa/repository/StockPriceJpaRepository.java` -- Adicionar a assinatura do método `Optional<StockPriceEntity> findFirstByCompanyIdAndPriceDate(String companyId, java.time.LocalDate priceDate)` -- Permite localizar registros de cotação duplicados/existentes com limite de 1 registro.
+- [x] `backend/valuation-service/src/main/java/afsdigital/grahamselect/valuation/infrastructure/persistence/ValuationRepositoryImpl.java` -- Modificar a gravação de `StockPriceEntity` para buscar se já existe cotação para o mesmo `companyId` e `priceDate`: se existir, atualizar o preço com o valor do novo preço recebido (garantindo o preço mais atualizado) e salvar; caso contrário, criar um novo registro com UUID aleatório -- Evita inserções duplicadas no banco para o mesmo dia e empresa.
+- [x] `backend/api/src/main/java/afsdigital/grahamselect/api/valuation/infrastructure/persistence/jpa/repository/RankingJpaRepository.java` -- Modificar a query nativa de ranking para dar JOIN em uma subquery deduplicada agrupando cotações por `company_id` e `price_date` (ex: `JOIN (SELECT company_id, price_date, MAX(price) as price FROM stock_price GROUP BY company_id, price_date) sp ON sp.company_id = lp.company_id AND sp.price_date = lp.latest_price_date`) -- Corrige o ranking para não duplicar linhas na listagem no frontend mesmo se houver dados históricos duplicados no banco.
+- [x] `frontend/lib/src/features/portfolio/presentation/providers/portfolio_provider.dart` -- Adicionar estados independentes `_tradeStatus` e `_tradeError` com seus respectivos getters, e atualizar `createManualTrade` e `resetStatus` para utilizarem/resetarem esses estados separadamente -- Evita colisões de SnackBar e fechamento do modal ao abrir.
+- [x] `frontend/lib/src/features/portfolio/presentation/widgets/manual_operation_entry.dart` -- Vincular `_tickerController` ao parâmetro `textEditingController` do `Autocomplete`, escutar `provider.tradeStatus` em vez de `provider.status`, atualizar os formatadores de campos numéricos de preço e quantidade para permitir vírgulas (`[0-9.,]`) e aplicar `.replaceAll(',', '.')` nas strings antes de executar o `double.parse(...)` -- Corrige os inputs de Ticker e de preço decimal, garantindo que o valor seja enviado corretamente.
+- [x] `frontend/test/features/portfolio/presentation/providers/portfolio_provider_test.dart` -- Atualizar os testes unitários do provider para validar as mudanças do `tradeStatus` -- Garante a integridade dos testes de unidade do frontend.
+
+**Acceptance Criteria:**
+- Given a company with existing stock price for a date, when inserting another stock price for the same date, then the existing record is updated and no new record is inserted.
+- Given stock price history with duplicate entries for the same date, when retrieving the top 20 best ranked companies, then each company is listed at most once.
+- Given the manual trade modal is opened, when rendering the UI, then the modal remains open and does not display a success toast message unless a trade is actively saved.
+- Given the user types a custom ticker manually in the trade modal, when saving the trade, then the typed ticker is successfully validated and submitted.
+- Given the user types a price with decimals using a comma (e.g., "40,89"), when saving the trade, then the value is successfully parseable and submitted.
+
+## Verification
+
+**Commands:**
+- `mvn clean test -pl backend/common,backend/api,backend/valuation-service` -- expected: Sucesso na execução de todos os testes no backend.
+- `flutter test` -- expected: Execução bem sucedida dos testes no frontend (rodar dentro da pasta `frontend`).
+
+**Manual checks (if no CLI):**
+- Abrir a aplicação com `./start-app.sh`, abrir o modal "Nova Operação" e garantir que o modal não fecha de imediato.
+- Inserir um ativo digitando manualmente e salvando (ex: `ITUB4` com preço `25.50` ou `25,50`).
+- Validar no painel "Top 20 Graham" se os ativos listados não se duplicam na tabela.

--- a/frontend/lib/src/features/portfolio/presentation/providers/portfolio_provider.dart
+++ b/frontend/lib/src/features/portfolio/presentation/providers/portfolio_provider.dart
@@ -7,6 +7,7 @@ import '../../domain/entities/monthly_evolution.dart';
 import '../../domain/repositories/portfolio_repository.dart';
 
 enum PortfolioStatus { initial, loading, success, error }
+enum TradeStatus { initial, loading, success, error }
 
 class PortfolioProvider extends ChangeNotifier {
   final PortfolioRepository repository;
@@ -19,6 +20,13 @@ class PortfolioProvider extends ChangeNotifier {
 
   String? _errorMessage;
   String? get errorMessage => _errorMessage;
+
+  // --- Estados independentes para criação de trade manual ---
+  TradeStatus _tradeStatus = TradeStatus.initial;
+  TradeStatus get tradeStatus => _tradeStatus;
+
+  String? _tradeError;
+  String? get tradeError => _tradeError;
 
   PortfolioSummary? _summary;
   PortfolioSummary? get summary => _summary;
@@ -46,8 +54,8 @@ class PortfolioProvider extends ChangeNotifier {
     required double price,
     required String broker,
   }) async {
-    _status = PortfolioStatus.loading;
-    _errorMessage = null;
+    _tradeStatus = TradeStatus.loading;
+    _tradeError = null;
     notifyListeners();
 
     try {
@@ -59,10 +67,10 @@ class PortfolioProvider extends ChangeNotifier {
         price: price,
         broker: broker,
       );
-      _status = PortfolioStatus.success;
+      _tradeStatus = TradeStatus.success;
     } catch (e) {
-      _status = PortfolioStatus.error;
-      _errorMessage = e.toString().replaceFirst('Exception: ', '');
+      _tradeStatus = TradeStatus.error;
+      _tradeError = e.toString().replaceFirst('Exception: ', '');
     }
     notifyListeners();
   }
@@ -70,6 +78,12 @@ class PortfolioProvider extends ChangeNotifier {
   void resetStatus() {
     _status = PortfolioStatus.initial;
     _errorMessage = null;
+    notifyListeners();
+  }
+
+  void resetTradeStatus() {
+    _tradeStatus = TradeStatus.initial;
+    _tradeError = null;
     notifyListeners();
   }
 

--- a/frontend/lib/src/features/portfolio/presentation/widgets/manual_operation_entry.dart
+++ b/frontend/lib/src/features/portfolio/presentation/widgets/manual_operation_entry.dart
@@ -48,8 +48,8 @@ class _ManualOperationEntryState extends State<ManualOperationEntry> {
         ticker: _tickerController.text.toUpperCase(),
         side: _type,
         tradeDate: _selectedDate,
-        quantity: double.parse(_quantityController.text),
-        price: double.parse(_priceController.text),
+        quantity: double.parse(_quantityController.text.replaceAll(',', '.')),
+        price: double.parse(_priceController.text.replaceAll(',', '.')),
         broker: _brokerController.text,
       );
     }
@@ -59,22 +59,22 @@ class _ManualOperationEntryState extends State<ManualOperationEntry> {
   Widget build(BuildContext context) {
     return Consumer<PortfolioProvider>(
       builder: (context, provider, child) {
-        if (provider.status == PortfolioStatus.success) {
+        if (provider.tradeStatus == TradeStatus.success) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(content: Text('Operação salva com sucesso!'), backgroundColor: Colors.green),
             );
-            provider.resetStatus();
+            provider.resetTradeStatus();
             Navigator.of(context).pop();
           });
         }
 
-        if (provider.status == PortfolioStatus.error) {
+        if (provider.tradeStatus == TradeStatus.error) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(provider.errorMessage ?? 'Erro ao salvar'), backgroundColor: Colors.red),
+              SnackBar(content: Text(provider.tradeError ?? 'Erro ao salvar'), backgroundColor: Colors.red),
             );
-            provider.resetStatus();
+            provider.resetTradeStatus();
           });
         }
 
@@ -121,6 +121,7 @@ class _ManualOperationEntryState extends State<ManualOperationEntry> {
 
                   // Ticker Autocomplete
                   Autocomplete<String>(
+                    textEditingController: _tickerController,
                     optionsBuilder: (TextEditingValue textEditingValue) {
                       if (textEditingValue.text == '') {
                         return const Iterable<String>.empty();
@@ -154,12 +155,12 @@ class _ManualOperationEntryState extends State<ManualOperationEntry> {
                       Expanded(
                         child: TextFormField(
                           controller: _quantityController,
-                          keyboardType: TextInputType.number,
+                          keyboardType: const TextInputType.numberWithOptions(decimal: true),
                           decoration: const InputDecoration(
                             labelText: 'Quantidade',
                             border: OutlineInputBorder(),
                           ),
-                          inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]'))],
+                          inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))],
                           validator: (value) => value == null || value.isEmpty ? 'Obrigatório' : null,
                         ),
                       ),
@@ -167,12 +168,12 @@ class _ManualOperationEntryState extends State<ManualOperationEntry> {
                       Expanded(
                         child: TextFormField(
                           controller: _priceController,
-                          keyboardType: TextInputType.number,
+                          keyboardType: const TextInputType.numberWithOptions(decimal: true),
                           decoration: const InputDecoration(
                             labelText: 'Preço Médio (R\$)',
                             border: OutlineInputBorder(),
                           ),
-                          inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]'))],
+                          inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))],
                           validator: (value) => value == null || value.isEmpty ? 'Obrigatório' : null,
                         ),
                       ),
@@ -204,8 +205,8 @@ class _ManualOperationEntryState extends State<ManualOperationEntry> {
                   const SizedBox(height: 32),
 
                   ElevatedButton(
-                    onPressed: provider.status == PortfolioStatus.loading ? null : _submit,
-                    child: provider.status == PortfolioStatus.loading
+                    onPressed: provider.tradeStatus == TradeStatus.loading ? null : _submit,
+                    child: provider.tradeStatus == TradeStatus.loading
                         ? const SizedBox(
                             height: 20,
                             width: 20,

--- a/frontend/lib/src/features/portfolio/presentation/widgets/manual_operation_entry.dart
+++ b/frontend/lib/src/features/portfolio/presentation/widgets/manual_operation_entry.dart
@@ -13,6 +13,7 @@ class ManualOperationEntry extends StatefulWidget {
 class _ManualOperationEntryState extends State<ManualOperationEntry> {
   final _formKey = GlobalKey<FormState>();
   final _tickerController = TextEditingController();
+  final _tickerFocusNode = FocusNode();
   final _quantityController = TextEditingController();
   final _priceController = TextEditingController();
   final _brokerController = TextEditingController();
@@ -22,6 +23,7 @@ class _ManualOperationEntryState extends State<ManualOperationEntry> {
   @override
   void dispose() {
     _tickerController.dispose();
+    _tickerFocusNode.dispose();
     _quantityController.dispose();
     _priceController.dispose();
     _brokerController.dispose();
@@ -122,6 +124,7 @@ class _ManualOperationEntryState extends State<ManualOperationEntry> {
                   // Ticker Autocomplete
                   Autocomplete<String>(
                     textEditingController: _tickerController,
+                    focusNode: _tickerFocusNode,
                     optionsBuilder: (TextEditingValue textEditingValue) {
                       if (textEditingValue.text == '') {
                         return const Iterable<String>.empty();

--- a/frontend/test/features/portfolio/presentation/providers/portfolio_provider_test.dart
+++ b/frontend/test/features/portfolio/presentation/providers/portfolio_provider_test.dart
@@ -220,6 +220,87 @@ void main() {
       expect(provider.errorMessage, isNull);
     });
 
+    group('createManualTrade — tradeStatus independente', () {
+      test('estado inicial do tradeStatus deve ser initial', () {
+        expect(provider.tradeStatus, equals(TradeStatus.initial));
+        expect(provider.tradeError, isNull);
+      });
+
+      test('deve atualizar tradeStatus para success após salvar com sucesso', () async {
+        final future = provider.createManualTrade(
+          ticker: 'PETR4',
+          side: 'BUY',
+          tradeDate: DateTime(2026, 6, 6),
+          quantity: 10,
+          price: 40.89,
+          broker: 'XP',
+        );
+
+        expect(provider.tradeStatus, equals(TradeStatus.loading));
+
+        await future;
+
+        expect(provider.tradeStatus, equals(TradeStatus.success));
+        expect(provider.tradeError, isNull);
+      });
+
+      test('deve atualizar tradeStatus para error quando o repositório lança exceção', () async {
+        mockRepository.shouldThrow = true;
+
+        await provider.createManualTrade(
+          ticker: 'PETR4',
+          side: 'BUY',
+          tradeDate: DateTime(2026, 6, 6),
+          quantity: 10,
+          price: 40.89,
+          broker: 'XP',
+        );
+
+        expect(provider.tradeStatus, equals(TradeStatus.error));
+        expect(provider.tradeError, equals('Failed to create manual trade'));
+      });
+
+      test('resetTradeStatus deve limpar tradeStatus e tradeError', () async {
+        mockRepository.shouldThrow = true;
+        await provider.createManualTrade(
+          ticker: 'PETR4',
+          side: 'BUY',
+          tradeDate: DateTime(2026, 6, 6),
+          quantity: 10,
+          price: 40.89,
+          broker: 'XP',
+        );
+
+        expect(provider.tradeStatus, equals(TradeStatus.error));
+
+        provider.resetTradeStatus();
+
+        expect(provider.tradeStatus, equals(TradeStatus.initial));
+        expect(provider.tradeError, isNull);
+      });
+
+      test('tradeStatus não deve impactar o status global do dashboard', () async {
+        // Carrega o dashboard com sucesso primeiro
+        await provider.loadSummary();
+        expect(provider.status, equals(PortfolioStatus.success));
+
+        // Salva um trade com sucesso
+        await provider.createManualTrade(
+          ticker: 'VALE3',
+          side: 'BUY',
+          tradeDate: DateTime(2026, 6, 6),
+          quantity: 5,
+          price: 65.00,
+          broker: 'Clear',
+        );
+
+        // Trade status atualiza, mas status do dashboard permanece intacto
+        expect(provider.tradeStatus, equals(TradeStatus.success));
+        expect(provider.status, equals(PortfolioStatus.success));
+      });
+    });
+
+
     group('loadEvolutionData', () {
       test('deve carregar os dados de evolução com sucesso', () async {
         const tEvolution = PortfolioEvolution(


### PR DESCRIPTION
## Problemas corrigidos

### 1. Duplicação de empresas no Top 20 Graham
- **Causa:** `ValuationRepositoryImpl` sempre criava um novo registro em `stock_price`, mesmo para o mesmo dia/empresa. O JOIN direto na query nativa multiplicava linhas.
- **Correção:** Upsert por `(company_id, price_date)` garante que o preço mais atualizado sobrescreve o existente sem criar duplicatas. A query nativa do ranking usa subquery agrupada como defesa extra.

### 2. Modal de Nova Operação fechando com sucesso falso
- **Causa:** `PortfolioProvider` compartilhava um único `_status` entre o dashboard e os trades manuais. Ao abrir o modal após carregar o dashboard (`status = success`), o modal respondia ao sucesso e fechava sozinho.
- **Correção:** Adicionado `TradeStatus` e estados `_tradeStatus`/`_tradeError` completamente independentes do status global.

### 3. Ticker customizado e preço com vírgula não aceitos
- **Causa:** `Autocomplete` sem `textEditingController` vinculado e `inputFormatters` bloqueando vírgula.
- **Correção:** `_tickerController` vinculado ao `Autocomplete`, formatadores aceitam `[0-9.,]` e `double.parse` normaliza vírgula para ponto antes do parse.

## Arquivos alterados

| Camada | Arquivo | Mudança |
|---|---|---|
| Backend | `StockPriceJpaRepository.java` | Método `findFirstByCompanyIdAndPriceDate` |
| Backend | `ValuationRepositoryImpl.java` | Upsert de cotação por data |
| Backend | `RankingJpaRepository.java` | Subquery agrupada na query nativa |
| Frontend | `portfolio_provider.dart` | `TradeStatus` independente |
| Frontend | `manual_operation_entry.dart` | Autocomplete + inputs decimais |
| Tests | `portfolio_provider_test.dart` | 5 novos testes para `tradeStatus` |

## Testes
- ✅ Backend: `mvn clean test` — BUILD SUCCESS (0 falhas)
- ✅ Frontend: `flutter test` — 83/83 passando
- ✅ `flutter analyze` — Sem issues

Refs: spec `docs/bmad/implementation-artifacts/spec-fix-top20-and-trade-modal-bugs.md`